### PR TITLE
Python 3.5 and Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,28 +41,28 @@ These steps will walk you through deploying the site on your local machine for t
   Create the database. You will only have to do this once. When prompted to create an admin user, say no. An admin account is loaded from the fixture data in the next step.
 
   ```
-  $ python manage.py syncdb
+  $ python3 manage.py syncdb
   ```
 
 5.
   Load initial data for the database, like an admin, groups, and various users. You will only have to do this once. Read more about what initial data is loaded in the "Fixture Data" section below.
 
   ```
-  $ python manage.py loaddata fixtures/dev_data.json
+  $ python3 manage.py loaddata fixtures/dev_data.json
   ```
 
 6.
   Collect static assets (CSS, JS, images, etc.).
 
   ```
-  $ python manage.py collectstatic
+  $ python3 manage.py collectstatic
   ```
 
 7.
   Run Django.
 
   ```
-  $ python manage.py runserver 0.0.0.0:8000
+  $ python3 manage.py runserver 0.0.0.0:8000
   ```
 
 8.

--- a/SigmaPi/SigmaPi/settings.py
+++ b/SigmaPi/SigmaPi/settings.py
@@ -2,7 +2,7 @@
 
 import os
 from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
-import environment_settings
+from . import environment_settings
 
 # These are settings which must change, depending on whether this is development
 # or production. So, we store them in a separate file.

--- a/SigmaPi/requirements.txt
+++ b/SigmaPi/requirements.txt
@@ -2,5 +2,4 @@ Django==1.8.7
 argparse==1.2.1
 beautifulsoup4==4.3.2
 requests==2.0.1
-wsgiref==0.1.2
 django-sendfile==0.3.4

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "bento/ubuntu-16.04"
   config.vm.network :forwarded_port, guest:8000, host:8000
   config.vm.provision :shell, :path => "install.sh"
 end

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,12 @@
 apt-get update -y
 
 # Python dev packages
-apt-get install -y build-essential python python-dev python-setuptools python-pip
+apt-get install -y build-essential python3-dev python3-pip
 
 # Git
 apt-get install -y git
 
-pip install -r /vagrant/SigmaPi/requirements.txt
+pip3 install -r /vagrant/SigmaPi/requirements.txt
 
 # Cleanup
 apt-get clean


### PR DESCRIPTION
We can now update to the next available Ubuntu LTS and safely use Python 3.5.