### PR TITLE
Quick, Fix the Donate Page

### DIFF
--- a/sigmapiweb/apps/PubSite/templates/public/donate.html
+++ b/sigmapiweb/apps/PubSite/templates/public/donate.html
@@ -1,28 +1,31 @@
-{% extends 'common/public_base.html' %}
+{% extends 'public/_article_base.html' %}
+{% block title %}Sigma Pi Gamma Iota - Donate{% endblock %}
+{% load staticfiles %}
 
 {% block content %}
 
-<h2>Help Support our Chapter</h2>
+    <div class="article-section">
+        <h1>Help Support our Chapter</h1>
+        <p>
+            You should be redirected momentarily to PayPal to donate. If not, please click the button below.
+        </p>
 
-<p>
-	You should be redirected momentarily to PayPal to donate. If not, please click the button below.
-</p>
-
-<div style="width: 90%; margin-left:auto; margin-right:auto;">
-	<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top" id="donate">
-		<input type="hidden" name="cmd" value="_s-xclick">
-		<input type="hidden" name="hosted_button_id" value="YLVYMHAQKSAN2">
-		<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-		<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-	</form>
-</div>
+        <div style="width: 90%; margin-left:auto; margin-right:auto;">
+            <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top" id="donate">
+                <input type="hidden" name="cmd" value="_s-xclick">
+                <input type="hidden" name="hosted_button_id" value="YLVYMHAQKSAN2">
+                <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+            </form>
+        </div>
+    </div>
 
 {% endblock %}
 
 {% block embedded_js %}
 <script type="text/javascript">
 	$(document).ready(function() {
-		$("#donate").submit();
+		//$("#donate").submit();
 	});
 </script>
 {% endblock %}

--- a/sigmapiweb/apps/PubSite/urls.py
+++ b/sigmapiweb/apps/PubSite/urls.py
@@ -50,7 +50,7 @@ urlpatterns = [
         name='pub-permission_denied',
     ),
     url(
-        regex=r'^donate/',
+        regex=r'^donate[/]$',
         view=views.donate,
         name='pub-donate',
     ),

--- a/sigmapiweb/common/settings/base.py
+++ b/sigmapiweb/common/settings/base.py
@@ -3,7 +3,7 @@ Base settings for Sigma Pi, Gamma Iota chapter website.
 """
 
 import os
-
+from collections import OrderedDict
 
 BASE_DIR = os.getcwd()
 
@@ -150,10 +150,11 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 SASS_PROCESSOR_AUTO_INCLUDE = False
 SASS_PRECISION = 8
 
-PUBLIC_PAGES = {
-    'Home': ('pub-index', None),
-    'About': ('pub-about', 'summer-house.jpg'),
-    'Service & Activities': ('pub-activities', 'volleyball.jpg'),
-    'Brothers':  ('userinfo-users', 'seniors-2017.jpg'),
-    'Log In': ('pub-login', None),  # This image is hard-coded into login_v1.scss
-}
+PUBLIC_PAGES = OrderedDict([
+    ('Home', ('pub-index', None)),
+    ('About', ('pub-about', 'summer-house.jpg')),
+    ('Service & Activities', ('pub-activities', 'volleyball.jpg')),
+    ('Brothers',  ('userinfo-users', 'seniors-2017.jpg')),
+    ('Donate', ('pub-donate', None)),
+    ('Log In', ('pub-login', None)),  # This image is hard-coded into login_v1.scss
+])


### PR DESCRIPTION
# Changes
- Fix the /donate url -- it used to request the 'Donate' context from settings, but this entry was never created
- Fix page ordering -- we used to use a dict in settings, but this does not guarantee ordering. This was quickly realized the hard way when adding a 'Donate' entry caused a rehash. The pages are now a collections.OrderedDict
- Fix the donate page styling -- it now looks like an article page.