### PR TITLE
Uncomment the auto redirect in the Donate Page

### DIFF
--- a/sigmapiweb/apps/PubSite/templates/public/donate.html
+++ b/sigmapiweb/apps/PubSite/templates/public/donate.html
@@ -25,7 +25,7 @@
 {% block embedded_js %}
 <script type="text/javascript">
 	$(document).ready(function() {
-		//$("#donate").submit();
+		$("#donate").submit();
 	});
 </script>
 {% endblock %}


### PR DESCRIPTION
I was in too much of a hurry with the previous PR, and had the auto-redirect commented out. This uncomments it. That is all.