### PR TITLE
Remove Javascript sorting on DataTables

### DIFF
--- a/sigmapiweb/apps/Archive/templates/archive/bylaws.html
+++ b/sigmapiweb/apps/Archive/templates/archive/bylaws.html
@@ -32,7 +32,7 @@
 	An archive of past bylaws may be viewed below.
 </p>
 <div class="table-responsive">
-	<table class="dataTable table">
+	<table class="dataTable-nosort table">
 		<thead>
 			<tr>
 				<th class="ten wide">Date</th>

--- a/sigmapiweb/apps/Archive/templates/archive/guides.html
+++ b/sigmapiweb/apps/Archive/templates/archive/guides.html
@@ -31,7 +31,7 @@
 
 {% if guides %}
 <div class="table-responsive">
-	<table class="dataTable table" id="guidesTable" onload="relTable()">
+	<table class="dataTable-nosort table" id="guidesTable" onload="relTable()">
 		<thead>
 			<tr>
 				<th class="two wide">Date Posted</th>

--- a/sigmapiweb/apps/Archive/templates/archive/rules.html
+++ b/sigmapiweb/apps/Archive/templates/archive/rules.html
@@ -32,7 +32,7 @@
 <p>
 	An archive of past house rules may be viewed below.
 <div class="table-responsive">
-	<table class="dataTable table">
+	<table class="dataTable-nosort table">
 		<thead>
 			<tr>
 				<th class="ten wide sorting_desc">Date</th>

--- a/sigmapiweb/apps/Scholarship/templates/scholarship/approve.html
+++ b/sigmapiweb/apps/Scholarship/templates/scholarship/approve.html
@@ -30,7 +30,7 @@
 <h4>Pending Academic Resources</h4>
 {% if resources %}
 <div class="table-responsive">
-	<table class="table dataTable">
+	<table class="table dataTable-nosort">
 		<thead>
 			<tr>
 				<th>Resource Name</th>
@@ -91,7 +91,7 @@
 <h4>Pending Library Items</h4>
 {% if items %}
 <div class="table-responsive">
-	<table class="table dataTable">
+	<table class="table dataTable-nosort">
 		<thead>
 			<tr>
 				<th>Library Item Name</th>

--- a/sigmapiweb/apps/Scholarship/templates/scholarship/library.html
+++ b/sigmapiweb/apps/Scholarship/templates/scholarship/library.html
@@ -45,7 +45,7 @@
 
 	{% if items %}
 	<div class="table-responsive">
-		<table class="table dataTable">
+		<table class="table dataTable-nosort">
 			<thead>
 				<tr>
 					<th>Name</th>

--- a/sigmapiweb/apps/Scholarship/templates/scholarship/resources.html
+++ b/sigmapiweb/apps/Scholarship/templates/scholarship/resources.html
@@ -44,7 +44,7 @@
 
 	{% if resources %}
 	<div class="table-responsive">
-		<table class="table dataTable">
+		<table class="table dataTable-nosort">
 			<thead>
 				<tr>
 					<th>Resource Name</th>

--- a/sigmapiweb/apps/Standards/templates/standards/index.html
+++ b/sigmapiweb/apps/Standards/templates/standards/index.html
@@ -42,7 +42,7 @@
 <div class="tab-content">
 	<div role="tabpanel" class="tab-pane fade in active" id="summons-history">
   		<div class="table-responsive no-spaced">
-	  		<table class="dataTable table">
+	  		<table class="dataTable-nosort table">
 				<thead>
 					<tr>
 						<th class="two wide">Date Received</th>

--- a/sigmapiweb/apps/Standards/templates/standards/summons.html
+++ b/sigmapiweb/apps/Standards/templates/standards/summons.html
@@ -39,7 +39,7 @@
 	<!-- Summons -->
 	<div role="tabpanel" class="tab-pane fade in active" id="summons">
 		<div class="table-responsive nospaced">
-	 		<table class="dataTable table">
+	 		<table class="dataTable-nosort table">
 	 			<thead>
 	 				<tr>
 	 					<th class="two wide">Date</th>
@@ -76,7 +76,7 @@
 
 	<div role="tabpanel" class="tab-pane fade" id="summons-history">
 		<div class="table-responsive">
-			<table class="table" id="summons-history-table">
+			<table class="dataTable-nosort table">
 				<thead>
 					<tr>
 						<th class="one wide">Date</th>
@@ -214,14 +214,6 @@
 		$("#reject-summons #reject-summons-description textarea").val($("#reason_" + id).html());
 
 		$("#reject-summons").modal('show');
-	});
-
-	// Disable Bootstrap sorting on the Summon History
-	$(document).ready(function () {
-		$('#summons-history-table').DataTable({
-			"bSort": false // false to disable sorting (or any other option)
-		});
-		$('.dataTables_length').addClass('bs-select');
 	});
 
 </script>

--- a/sigmapiweb/apps/Standards/templates/standards/summons_requests.html
+++ b/sigmapiweb/apps/Standards/templates/standards/summons_requests.html
@@ -35,7 +35,7 @@
 	<!-- Summons -->
 	<div id="summons" class="tab-pane active">
 		<div class="table-responsive nospaced">
-	 		<table class="dataTable table">
+	 		<table class="dataTable-nosort table">
 	 			<thead>
 	 				<tr>
 	 					<th class="two wide">Date</th>

--- a/sigmapiweb/apps/UserInfo/templates/userinfo/secure/manage.html
+++ b/sigmapiweb/apps/UserInfo/templates/userinfo/secure/manage.html
@@ -13,7 +13,7 @@
 
 {% if all_users %}
 <div class="table-responsive">
-	<table class="dataTable table">
+	<table class="dataTable-nosort table">
 		<thead>
 			<tr>
 				<th class="three wide">First Name</th>

--- a/sigmapiweb/static/js/secure/autotable.js
+++ b/sigmapiweb/static/js/secure/autotable.js
@@ -9,6 +9,13 @@ $(document).ready(function () {
 	$.fn.dataTableExt.oStdClasses["sPageNextDisabled"] = "btn btn-primary disabled dataTable-button-right"
 
 	// Initialize all data table instances.
+
 	$(".dataTable").DataTable();
-	
+
+	// NOTE: THIS IS A CUSTOM CLASS BECAUSE WE DO NOT WANT AUTOSORTING
+	// MOST OF THE TIME
+	// TAGS: dataTable DataTable bSort sorting tablesort data-table
+	$(".dataTable-nosort").DataTable({
+		"bSort": false // false to disable sorting
+	});
 });


### PR DESCRIPTION
- Added `dataTable-nosort` as a valid html-class

- `-nosort` will create a dataTable with the sorting option disabled

- Switched over existing dataTables to -nosort variant

This update will require a new `collectstatic` and for the visitors to hard refresh. This could be fixed by renaming the file, but that might just be more complicated.